### PR TITLE
Make the filter state instance data

### DIFF
--- a/EMGFilters.h
+++ b/EMGFilters.h
@@ -36,6 +36,39 @@ enum NOTCH_FREQUENCY { NOTCH_FREQ_50HZ = 50, NOTCH_FREQ_60HZ = 60 };
 
 enum SAMPLE_FREQUENCY { SAMPLE_FREQ_500HZ = 500, SAMPLE_FREQ_1000HZ = 1000 };
 
+enum FILTER_TYPE {
+    FILTER_TYPE_LOWPASS = 0,
+    FILTER_TYPE_HIGHPASS,
+};
+
+class FILTER_2nd {
+  private:
+    // second-order filter
+    float states[2];
+    float num[3];
+    float den[3];
+
+  public:
+    void init(FILTER_TYPE ftype, int sampleFreq);
+
+    float update(float input);
+};
+
+class FILTER_4th {
+  private:
+    // fourth-order filter
+    // cascade two 2nd-order filters
+    float states[4];
+    float num[6];
+    float den[6];
+    float gain;
+
+  public:
+    void init(int sampleFreq, int humFreq);
+
+    float update(float input);
+};
+
 // \brief EMGFilter provides an anti-hum notch filter to filter out 50HZ or
 //        60HZ power line noise, a lowpass filter to filter out signals above
 //        150HZ, and a highpass filter to filter out noise below 20HZ;
@@ -71,6 +104,9 @@ class EMGFilters {
     bool             m_notchFilterEnabled;
     bool             m_lowpassFilterEnabled;
     bool             m_highpassFilterEnabled;
+    FILTER_2nd       LPF;
+    FILTER_2nd       HPF;
+    FILTER_4th       AHF;
 };
 
 #endif


### PR DESCRIPTION
The filter state is presently stored in the [global variables][state] `LPF`, `HPF` and `AHF`. The fact that these are global means that all instances of `EMGFilters` share the same state, and thus interact with each other.

This pull request makes this state per-instance data, thus making it possible to use multiple filter instances.

Fixes #3.
Fixes #7.

Note: the patch looks big, but only because the indentation level changed for the methods of `FILTER_2nd` and `FILTER_4th`. If displayed as `git diff -b`, it is a small patch.

[state]: ../blob/280897438e71bdf893913e14f1f2c9c64ffbd591/EMGFilters.cpp#L185-L187