### PR TITLE
Avoid signed integer overflow in example sketch

### DIFF
--- a/examples/SimpleEMGFilters/SimpleEMGFilters.ino
+++ b/examples/SimpleEMGFilters/SimpleEMGFilters.ino
@@ -98,10 +98,10 @@ void loop() {
     int data = analogRead(SensorInputPin);
 
     // filter processing
-    int dataAfterFilter = myFilter.update(data);
+    long dataAfterFilter = myFilter.update(data);
 
     // Get envelope by squaring the input
-    int envelope = sq(dataAfterFilter);
+    long envelope = sq(dataAfterFilter);
 
     if (CALIBRATE) {
         Serial.print("Squared Data: ");


### PR DESCRIPTION
Running the example sketch [SimpleEMGFilters.ino][] on an Arduino Uno, I got the output:

```text
Squared Data: 1600
Squared Data: 20164
Squared Data: 4294951489
```

The last line is suspicious: not only is it too large to be plausible, it is even way larger than `INT_MAX`, which should not be possible for an `int`.

Further investigation revealed the source of the problem to be an integer overflow in the computation of the square of `dataAfterFilter`. Signed integer overflow is undefined behavior in C++. [Undefined behavior][] means that anything can happen, including “impossible” results like above.

Computing the square as a `long` solves the issue.

[SimpleEMGFilters.ino]: ../blob/280897438e71bdf893913e14f1f2c9c64ffbd591/examples/SimpleEMGFilters/SimpleEMGFilters.ino
[Undefined behavior]: https://www.nayuki.io/page/undefined-behavior-in-c-and-cplusplus-programs